### PR TITLE
cloud buildではrelease buildする

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -75,6 +75,8 @@ steps:
   - '--path=target/release'
   waitFor: ['cargo-test']
 
+timeout: 1200s
+
 images:
 - 'gcr.io/$PROJECT_ID/solver'
 - 'gcr.io/$PROJECT_ID/solver:$COMMIT_SHA'


### PR DESCRIPTION
キャッシュが効いていない状態だと時間がかかるようになるので[timeout](https://cloud.google.com/cloud-build/docs/build-config?hl=ja#timeout_2)も増やしています。 
